### PR TITLE
Added support for gzipped request body decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +258,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -446,6 +471,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "num-integer"
@@ -698,6 +732,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "flate2",
  "log",
  "rusqlite",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ rusqlite = {version = "0.24", features = ["bundled"]}
 rust-embed = "5"
 log = "^0.4"
 env_logger = "^0.9"
+flate2 = { version = "=1.0.26", features = [] }


### PR DESCRIPTION
- Added dependencies on `flate2:1.0.26` in Cargo.toml, (1.0.27 breaks docker build).
- Refactored request body reading in `src/serve.rs` to support both gzip-encoded and plain request bodies.

To test the new function, use the following shell command:

```
echo '{"mydummy": "json"}' | gzip | curl -v -i --data-binary @- -H "Content-Encoding: gzip" -H 'Content-Type: application/json' http://localhost:8000/test_endpoint
```